### PR TITLE
Add _dict/* linguist-vendored to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.go -crlf
 
 readutil/readlines_test*.txt -crlf
+_dict/* linguist-vendored


### PR DESCRIPTION
![Capture 2021-06-12 23 48 22](https://user-images.githubusercontent.com/4703128/121780307-a9fa6300-cbda-11eb-9a0a-5f318367aa11.png)
Currentry this project is recognized as a CommonLisp project.

GitHub uses [linguist](https://github.com/github/linguist) and maybe it mis-recognize `_dict/*` files as a CommonLisp files.
That line I added tells it the `_dict/*` is not meaningful source code and just ignoreable to guess project language.

---
I reference this [stack overflow](https://stackoverflow.com/questions/34713765/github-changes-repository-to-wrong-language) thread.
@tomoya tell me [linguist documentation](https://github.com/github/linguist/blob/master/docs/overrides.md).