### PR TITLE
Multiple clauses

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: [push]
 
+env:
+  GO_VERSION: '>=1.21.0'
+
 jobs:
 
   build:
@@ -13,11 +16,11 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
 
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.x
+    - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
 
     - run: go test ./...
 

--- a/cmd/gmigemo/main.go
+++ b/cmd/gmigemo/main.go
@@ -56,5 +56,5 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	queryLoop(cli.NewConsole(), dict)
+	queryLoop(cli.NewConsole(), migemo.MultiClauses(dict))
 }

--- a/dict/load_skk.go
+++ b/dict/load_skk.go
@@ -3,7 +3,7 @@ package dict
 import (
 	"io"
 
-	"github.com/koron/go-skkdict"
+	"github.com/koron-go/skkdict"
 )
 
 func addDictEntry(d *Dict, entry *skkdict.Entry) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/koron-go/skkdict v1.0.0
 	github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765
-	github.com/koron/go-skkdict v0.0.0-20160727125427-1bfa372d61d2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/koron/gomigemo
 
-go 1.16
+go 1.21
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765
 	github.com/koron/go-skkdict v0.0.0-20160727125427-1bfa372d61d2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765 h1:/k2Hth0PQq47SNc2pvOnwEQbjtu7HgtQu8TFXKhABKE=
 github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765/go.mod h1:TJD1ti844npsMLPGgPPLa1Ozaz0W36N9EL6dQmTZ0kU=
 github.com/koron/go-skkdict v0.0.0-20160727125427-1bfa372d61d2 h1:ibW6FKhStt/gAMEndugP/3kNb/Dm+eWEx9rjCMN37A8=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/koron-go/skkdict v1.0.0 h1:N8U7nFJt6ddKt52i1FoG5ukzjHgqlHqtscjK8UcmUCM=
+github.com/koron-go/skkdict v1.0.0/go.mod h1:Pd4MKJybKeA6yzuUNfXqV5+8SBSb3PEvowZ3orQfC4M=
 github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765 h1:/k2Hth0PQq47SNc2pvOnwEQbjtu7HgtQu8TFXKhABKE=
 github.com/koron/gelatin v0.0.0-20160729020448-88d6a03ce765/go.mod h1:TJD1ti844npsMLPGgPPLa1Ozaz0W36N9EL6dQmTZ0kU=
-github.com/koron/go-skkdict v0.0.0-20160727125427-1bfa372d61d2 h1:ibW6FKhStt/gAMEndugP/3kNb/Dm+eWEx9rjCMN37A8=
-github.com/koron/go-skkdict v0.0.0-20160727125427-1bfa372d61d2/go.mod h1:RHH1ylFPxnWBxAbpUZraJ4iCu4GO0jvbvx0VIDawT8w=

--- a/migemo/multiclause.go
+++ b/migemo/multiclause.go
@@ -1,0 +1,128 @@
+package migemo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// mcDict means multiple clause (renbun) dictionary.
+type mcDict struct {
+	dict Dict
+}
+
+// MultiClauses creates a new Dict which supports multiple clauses (renbun)
+// conversion based on given Dict.
+func MultiClauses(dict Dict) Dict {
+	return mcDict{dict: dict}
+}
+
+// Matcher returns a new Matcher object which generated from query.
+
+func (d mcDict) Matcher(query string) (Matcher, error) {
+	clauses, err := splitClauses(query)
+	if err != nil {
+		return nil, err
+	}
+	if len(clauses) == 0 {
+		return nil, errors.New("no clauses in query")
+	}
+	mm := make(mcMatcher, len(clauses))
+	for i, c := range clauses {
+		m, err := d.dict.Matcher(strings.ToLower(c))
+		if err != nil {
+			return nil, fmt.Errorf("clause #%d %q failed to create a matcher: %w", i, c, err)
+		}
+		mm[i] = m
+	}
+	return mm, nil
+}
+
+type mcMatcher []Matcher
+
+func (mm mcMatcher) Match(s string) (chan Match, error) {
+	// TODO:
+	return nil, errors.New("Match method of multi-clause is not implemented yet")
+}
+
+func (mm mcMatcher) Pattern() (string, error) {
+	var bb bytes.Buffer
+	o := mm[0].GetOptions()
+	for i, m := range mm {
+		p, err := m.Pattern()
+		if err != nil {
+			return "", fmt.Errorf("clause #%d failed to generate pattern: %w", i, err)
+		}
+		// Consider MatcherOptions when concatenate.
+		if bb.Len() > 0 {
+			bb.WriteString(o.OpWSpaces)
+		}
+		bb.WriteString(p)
+	}
+	return bb.String(), nil
+}
+
+func (mm mcMatcher) SetOptions(o MatcherOptions) {
+	for _, m := range mm {
+		m.SetOptions(o)
+	}
+}
+
+func (mm mcMatcher) GetOptions() MatcherOptions {
+	return mm[0].GetOptions()
+}
+
+// splitClauses separates a string into clauses.  The break between clauses is
+// usually an uppercase letter.  Clauses that begin with multiple capital
+// letters are separated by non-capital letters.
+func splitClauses(query string) ([]string, error) {
+	a := make([]string, 0, 8)
+	mode := 0
+	cstart := -1
+	for i, ch := range query {
+		if mode == 0 {
+			cstart = i
+			if unicode.IsUpper(ch) {
+				mode = 2
+				continue
+			}
+			mode = 1
+			continue
+		}
+		// start with lower char.
+		if mode == 1 {
+			if unicode.IsUpper(ch) {
+				mode = 2
+				a = append(a, query[cstart:i])
+				cstart = i
+				continue
+			}
+			continue
+		}
+		// start with upper char, process 2nd char
+		if mode == 2 {
+			if unicode.IsUpper(ch) {
+				mode = 3
+				continue
+			}
+			mode = 1
+			continue
+		}
+		// start with two upper chars
+		if mode == 3 {
+			if !unicode.IsUpper(ch) {
+				mode = 1
+				a = append(a, query[cstart:i])
+				cstart = i
+				continue
+			}
+			continue
+		}
+	}
+	if cstart < len(query) {
+		a = append(a, query[cstart:])
+	}
+	return a, nil
+}

--- a/migemo/multiclause_test.go
+++ b/migemo/multiclause_test.go
@@ -1,0 +1,29 @@
+package migemo
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSplitClauses(t *testing.T) {
+	for i, tc := range []struct {
+		in   string
+		want []string
+	}{
+		{"abc", []string{"abc"}},
+		{"abcDef", []string{"abc", "Def"}},
+		{"abcDEFghi", []string{"abc", "DEF", "ghi"}},
+
+		{"aaa0", []string{"aaa0"}},
+		{"AAA0", []string{"AAA", "0"}},
+	} {
+		got, err := splitClauses(tc.in)
+		if err != nil {
+			t.Errorf("unexpected error at #%d (%+v): %s", i, tc, err)
+		}
+		if d := cmp.Diff(tc.want, got); d != "" {
+			t.Errorf("output mismatch: -want +got\n%s", d)
+		}
+	}
+}


### PR DESCRIPTION
fix #10 

連文節のサポート

ただし現在は正規表現パターンの生成(Patternメソッド)しかサポートしていない。
chanを使うMatchメソッドのほうは実装目途が立っていない。